### PR TITLE
Syntax Error Fix

### DIFF
--- a/code.c
+++ b/code.c
@@ -46,9 +46,9 @@ if (root == NULL) {
 printf("No flights available.\n");
 return root;
 }
-printf("Flight booked from %s to %s for %s with age %d. Price:
-%.2f\n",
-root->source, root->destination, root->name, root->age, root->price);
+printf("Flight booked from %s to %s for %s with age %d. Price: %.2f\n",
+       root->source, root->destination, root->name, root->age, root->price);
+
 // Update the priority queue after booking
 return root->right;
 }


### PR DESCRIPTION
**Error:**
The `printf` function call is missing a closing quotation mark, resulting in a syntax error. Additionally, there is a stray newline character that is not properly handled.

**Fix:**
Ensure that the format string for `printf` is properly enclosed in quotation marks and that all formatting specifiers are correctly placed.

**Corrected Code:**

```c
printf("Flight booked from %s to %s for %s with age %d. Price: %.2f\n",
       root->source, root->destination, root->name, root->age, root->price);
```

**Short Description of the Fix:**
The fix involves adding the missing closing quotation mark and ensuring the format string is continuous without unintended line breaks.

**Testing:**
Compiled the code and verified that the `printf` function executes correctly and produces the expected output. There are no syntax errors or warnings related to the format string.